### PR TITLE
Support an optional 'unavailable' flag on Plans

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -52,4 +52,5 @@ export interface PlanMapping {
     equivalentBillingIds? : Array<string>;
     name : string;
     default?: boolean;
+    unavailable?: boolean;
 }

--- a/src/controllers/AccountsController.ts
+++ b/src/controllers/AccountsController.ts
@@ -135,6 +135,10 @@ export class AccountsController implements IAccountsController {
                 throw new Error("Failed to find plan");
             }
 
+            if (planInfo.unavailable) {
+                throw new Error("Cannot subscribe to unavailable plan");
+            }
+
             return this.lock.acquire(LockNames.WebhookFreeze, async () => {
                 // Subscribe in billing system first - it may fail due to no payment method, etc. But at this point we have
                 // not done anything with RL API, so it's OK

--- a/src/controllers/PlansController.ts
+++ b/src/controllers/PlansController.ts
@@ -17,7 +17,8 @@ export class PlansController implements IPlansController {
         return (await this.plans.getAll()).map((p) => {
             return {
                 id: p.id,
-                name: p.name
+                name: p.name,
+                unavailable: p.unavailable || undefined
             }
         });
     }

--- a/src/http/HttpTypes.ts
+++ b/src/http/HttpTypes.ts
@@ -2,7 +2,7 @@ export type AccountCreateRequest = {userId: string, routerPairingCode?: string};
 export type AccountCreateResponse = {account: ApiAccount, apiKey : string};
 export type AccountUpdateRequest = {active?: boolean, planId?: string};
 export type ApiAccount = {id: string, active: boolean, plan?: ApiPlan};
-export type ApiPlan = {id: string, name: string};
+export type ApiPlan = {id: string, name: string, unavailable?: boolean};
 export type PaymentMethod = {id: string, isDefault: boolean, cardInfo: {brand: string, expMonth: number, expYear: number, last4: string}};
 export type PaymentMethodCreateRequest = {token: string, setDefault? : boolean};
 

--- a/src/models/PlansModel.ts
+++ b/src/models/PlansModel.ts
@@ -63,6 +63,10 @@ export class PlansModel implements IPlansModel {
             throw new Error("A default plan must be configured");
         }
 
+        if (defaultPlan.unavailable) {
+            throw new Error("Default plan must not be unavailable");
+        }
+
         this.defaultPlan = defaultPlan;
     }
 

--- a/src/test/PlansModel.ts
+++ b/src/test/PlansModel.ts
@@ -31,5 +31,15 @@ describe("PlansModel", () => {
        if (!p || p.id !== id || p.name !== name || p.billingId !== billingId) {
            throw new Error("Wrong data");
        }
-   })
+   });
+
+    it("Doesn't allow unavailable default", () => {
+        try {
+            new PlansModel([{id: "id", name: "SomeName", billingId: "SomeBillingId", default:true, unavailable: true}]);
+        } catch(e) {
+            // Good - expect throw
+            return;
+        }
+        throw new Error("Expected error");
+    })
 });

--- a/util/api.yaml
+++ b/util/api.yaml
@@ -163,6 +163,9 @@ definitions:
         type: string
         example: Deluxe Plan
         description: friendly name for the plan
+      unavailable:
+        type: boolean
+        description: If true, this plan cannot accept new subscriptions
   PlanListResponse:
     allOf:
       - $ref: '#/definitions/PaginatedResponse'


### PR DESCRIPTION
@hytea we're adding this flag to the billing API. An unavailable plan is one that cannot accept new subscriptions. So probably plans with this flag should be hidden from the plan selection dropdown (or similar) in UI. Let me know if this doesn't make sense.