### PR TITLE
Proxy user creation requests through billing API

### DIFF
--- a/src/controllers/ProxyUserController.ts
+++ b/src/controllers/ProxyUserController.ts
@@ -1,0 +1,42 @@
+import {UserApi} from "../routerlimits/api/api/userApi";
+import {Configuration} from "../Configuration";
+
+export interface IProxyUserController {
+    createUser(params : object) : Promise<string>;
+}
+
+export class MockProxyUserController implements IProxyUserController {
+    async createUser(params: object): Promise<string> {
+        return "asdf567";
+    }
+}
+
+export class ProxyUserController implements IProxyUserController {
+    private readonly config : Configuration;
+
+    constructor(config : Configuration) {
+        this.config = config;
+    }
+
+    async createUser(params : any) : Promise<string> {
+        const api = new UserApi();
+        // Insufficient to set key here because swagger doesn't handle optional authentication and won't include the key
+        // Instead, we do it manually below
+        // api.setApiKey(UserApiApiKeys.userApiKeyAuth, this.config.routerlimits.apiKey);
+
+        if (this.config.routerlimits.apiBase) {
+            api.basePath = this.config.routerlimits.apiBase;
+        }
+
+        if (params.organizationId) {
+            throw new Error("Parameter not allowed");
+        }
+
+        const res = await api.usersPost(params, {headers: {'x-api-key' : "this.config.routerlimits.apiKey"}});
+
+        if (!res || !res.body || !res.body.userId) {
+            throw new Error("Unknown error creating user");
+        }
+        return res.body.userId;
+    }
+}

--- a/src/controllers/ProxyUserController.ts
+++ b/src/controllers/ProxyUserController.ts
@@ -32,7 +32,7 @@ export class ProxyUserController implements IProxyUserController {
             throw new Error("Parameter not allowed");
         }
 
-        const res = await api.usersPost(params, {headers: {'x-api-key' : "this.config.routerlimits.apiKey"}});
+        const res = await api.usersPost(params, {headers: {'x-api-key' : this.config.routerlimits.apiKey}});
 
         if (!res || !res.body || !res.body.userId) {
             throw new Error("Unknown error creating user");

--- a/src/http/ProxyUsersReceiver.ts
+++ b/src/http/ProxyUsersReceiver.ts
@@ -1,0 +1,38 @@
+import {NextFunction, Request, Response} from "express";
+import {IProxyUserController} from "../controllers/ProxyUserController";
+import {ILoggingModel, LogLevel} from "../models/LoggingModel";
+
+export class ProxyUsersReceiver {
+    private controller : IProxyUserController;
+    private log : ILoggingModel;
+
+    constructor(controller : IProxyUserController, log: ILoggingModel) {
+        this.controller = controller;
+        this.log = log;
+    }
+
+    userCreate = async (req : Request, res: Response, next: NextFunction) => {
+        let userId;
+
+        try {
+            userId = await this.controller.createUser(req.body);
+        } catch(e) {
+            if (e.message) {
+                this.log.log(LogLevel.ERROR, "Error doing proxy user create", {message: e.message, stack: e.stack});
+            }
+            else if (e.response) {
+                this.log.log(LogLevel.ERROR, "Error doing proxy user create", {remoteStatus: e.response.statusCode, body: e.response.body});
+            }
+            res.sendStatus(500);
+            return;
+        }
+
+        this.log.log(LogLevel.INFO, "User created", {requestBody: req.body, userId: userId});
+
+        res.status(201);
+        res.json({
+            userId : userId,
+            authorizationRequired: false
+        })
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import AsyncLock from 'async-lock';
 import {PlansController} from "./controllers/PlansController";
 import {ConsoleLoggingModel, LogLevel} from "./models/LoggingModel";
 import mysql from "mysql";
+import {ProxyUserController} from "./controllers/ProxyUserController";
 
 const c : Configuration = config.util.toObject();
 
@@ -51,7 +52,8 @@ const c : Configuration = config.util.toObject();
     const authController : IAuthenticationController = new AuthenticationController(c, accounts, apiKeys);
     const accountsController = new AccountsController(billing, accounts, apiKeys, rl, plans, lock);
     const plansController = new PlansController(plans);
+    const proxyUsersController = new ProxyUserController(c);
 
-    const apiServer = new ApiServer(c, rlWebhooks, billingWebhooks, authController, accountsController, plansController, log);
+    const apiServer = new ApiServer(c, rlWebhooks, billingWebhooks, authController, accountsController, plansController, proxyUsersController, log);
     log.log(LogLevel.INFO, `API and Webhook handlers listening on port ${apiServer.listenPort}`);
 })();

--- a/src/test/routerlimitswebhooks.ts
+++ b/src/test/routerlimitswebhooks.ts
@@ -22,6 +22,7 @@ import {IRouterLimitsModel, MockRouterLimitsModel} from "../models/RouterLimitsM
 import {PlansController} from "../controllers/PlansController";
 import {IPlansModel, PlansModel} from "../models/PlansModel";
 import {LogLevel, NullLoggingModel} from "../models/LoggingModel";
+import {MockProxyUserController} from "../controllers/ProxyUserController";
 
 const generateTestWebhookObj = () => {
     return {
@@ -97,8 +98,9 @@ describe("Router Limits Webhooks", () => {
             accountsController = new AccountsController(billing, accounts, apiKeys, rl, plans, lock);
             processor = new MockRouterLimitsWebhookController();
             const plansController = new PlansController(plans);
+            const proxyUsersController = new MockProxyUserController();
 
-            api = new ApiServer(config, processor, billingController, authController, accountsController, plansController, new NullLoggingModel());
+            api = new ApiServer(config, processor, billingController, authController, accountsController, plansController, proxyUsersController, new NullLoggingModel());
         });
 
         afterEach(() => {

--- a/util/api.yaml
+++ b/util/api.yaml
@@ -174,9 +174,52 @@ definitions:
             type: array
             items:
               $ref: '#/definitions/Plan'
-
-
-
+  UserCreationRequest:
+    type: object
+    properties:
+      firstName:
+        type: string
+      lastName:
+        type: string
+      email:
+        type: string
+        format: email
+      phone:
+        type: string
+      address:
+        type: string
+      address2:
+        type: string
+      address3:
+        type: string
+      city:
+        type: string
+      state:
+        type: string
+      zip:
+        type: string
+      country:
+        type: string
+    required:
+      - firstName
+      - lastName
+      - email
+      - phone
+      - address
+      - city
+      - state
+      - zip
+      - country
+  UserCreateResponse:
+    type: object
+    properties:
+      userId:
+        type: string
+      authorizationRequired:
+        type: boolean
+    required:
+      - userId
+      - authorizationRequired
 paths:
   /authenticate:
     post:
@@ -375,3 +418,22 @@ paths:
           description: These plans are available
           schema:
             $ref: '#/definitions/PlanListResponse'
+  /proxy/users:
+    post:
+      tags:
+        - Proxy
+      description: >-
+        Proxies a request to create a user to the Router Limits API, providing
+        credentials needed to ensure that verification emails are whitelabeled
+        when appropriate
+      parameters:
+        - in: body
+          name: body
+          required: true
+          schema:
+            $ref: '#/definitions/UserCreationRequest'
+      responses:
+        '201':
+          description: user created
+          schema:
+            $ref: '#/definitions/UserCreateResponse'


### PR DESCRIPTION
So that billing API can add credentials to the request, ensuring that welcome/verification emails are whitelabeled when appropriate.

@hytea we need to adjust the billing portal so that it uses this endpoint instead of the RL user creation endpoint